### PR TITLE
Add tests for SeasonStatsDownloader

### DIFF
--- a/tests/stats/test_save_season_stats.py
+++ b/tests/stats/test_save_season_stats.py
@@ -1,0 +1,81 @@
+import json
+import pandas as pd
+import os
+import pytest
+
+from mlb_data_lab.stats import save_season_stats
+from mlb_data_lab.stats.save_season_stats import SeasonStatsDownloader
+
+
+def test_get_team_ids_by_league(tmp_path, monkeypatch):
+    data_dir = tmp_path
+    teams = [
+        {"mlbam_team_id": 1, "league": "AL"},
+        {"mlbam_team_id": 2, "league": "NL"},
+        {"mlbam_team_id": 3, "league": "AL"}
+    ]
+    (data_dir / "mlb_teams.json").write_text(json.dumps(teams))
+    monkeypatch.setattr(save_season_stats, "DATA_DIR", str(data_dir))
+    downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path))
+    ids = downloader.get_team_ids_by_league("AL")
+    assert ids == [1, 3]
+
+
+def test_flush_to_disk(tmp_path):
+    downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path))
+    file_path = tmp_path / "out.csv"
+    df1 = pd.DataFrame({"A": [1, 2]})
+    df2 = pd.DataFrame({"A": [3]})
+    downloader._flush_to_disk([df1], str(file_path), True)
+    downloader._flush_to_disk([df2], str(file_path), False)
+    df = pd.read_csv(file_path)
+    assert df["A"].tolist() == [1, 2, 3]
+
+
+class DummyClient:
+    def __init__(self):
+        self.pitch_df = pd.DataFrame({"wins": [1]})
+        self.bat_df = pd.DataFrame({"hits": [5]})
+
+    def fetch_pitching_stats(self, mlbam_id, season):
+        return self.pitch_df
+
+    def fetch_batting_stats(self, mlbam_id, season):
+        return self.bat_df
+
+
+class DummyPlayerInfo:
+    def __init__(self, pos):
+        self.primary_position = pos
+
+
+class DummyBio:
+    full_name = "Dummy Player"
+
+
+class DummyPlayer:
+    def __init__(self, pos):
+        self.player_info = DummyPlayerInfo(pos)
+        self.player_bio = DummyBio()
+
+
+def test_fetch_player_stats_success(monkeypatch, tmp_path):
+    client = DummyClient()
+    downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path))
+    downloader.client = client
+    monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
+    df = downloader._fetch_player_stats(1)
+    assert isinstance(df, pd.DataFrame)
+    assert df["mlbam_id"].iloc[0] == 1
+    assert df["season"].iloc[0] == 2024
+    assert downloader.statuses["success"] == ["Dummy Player"]
+
+
+def test_fetch_player_stats_position_mismatch(monkeypatch, tmp_path):
+    client = DummyClient()
+    downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path), player_type="batters")
+    downloader.client = client
+    monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
+    result = downloader._fetch_player_stats(2)
+    assert result is None
+    assert downloader.statuses["position_mismatch"] == ["Dummy Player"]

--- a/tests/stats/test_save_season_stats_integration.py
+++ b/tests/stats/test_save_season_stats_integration.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import pytest
+from mlb_data_lab.stats.save_season_stats import SeasonStatsDownloader
+
+
+@pytest.mark.integration
+def test_fetch_player_stats_integration(tmp_path):
+    downloader = SeasonStatsDownloader(season=2023, output_dir=str(tmp_path))
+    df = downloader._fetch_player_stats(545361)  # Mike Trout
+    assert df is not None
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert (df["mlbam_id"] == 545361).all()


### PR DESCRIPTION
## Summary
- add unit tests for stats downloader logic
- add integration test to exercise live data pull

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ed4728248326a5113d0726cfd86c