### PR TITLE
Add PitchData class and sample dataset

### DIFF
--- a/mlb_data_lab/data/pitch-data-2025-06-18.csv
+++ b/mlb_data_lab/data/pitch-data-2025-06-18.csv
@@ -1,0 +1,6 @@
+pitcher,pitch_type,release_speed,release_spin_rate,swing,whiff
+1,FF,95,2300,10,2
+1,SL,86,2500,5,1
+2,FF,96,2400,8,3
+2,CH,85,2100,4,0
+1,CU,78,2600,2,1

--- a/mlb_data_lab/pitch_data.py
+++ b/mlb_data_lab/pitch_data.py
@@ -1,0 +1,56 @@
+import os
+import pandas as pd
+
+from mlb_data_lab.config import DATA_DIR
+
+class PitchData:
+    """Load and provide helpers for pitch level Statcast data."""
+
+    def __init__(self, file_name: str = "pitch-data-2025-06-18.csv", data_dir: str = DATA_DIR):
+        self.file_path = os.path.join(data_dir, file_name)
+        self.data = None
+
+    def load(self) -> pd.DataFrame:
+        """Read the CSV file into a DataFrame."""
+        if not os.path.exists(self.file_path):
+            raise FileNotFoundError(f"File not found: {self.file_path}")
+        self.data = pd.read_csv(self.file_path)
+        return self.data
+
+    def _ensure_loaded(self):
+        if self.data is None:
+            self.load()
+
+    def get_pitch_types(self):
+        """Return a list of unique pitch types."""
+        self._ensure_loaded()
+        if 'pitch_type' in self.data.columns:
+            return self.data['pitch_type'].unique().tolist()
+        return []
+
+    def pitches_by_pitcher(self, pitcher_id: int) -> pd.DataFrame:
+        """Return all pitches thrown by a given pitcher."""
+        self._ensure_loaded()
+        if 'pitcher' not in self.data.columns:
+            raise ValueError("Column 'pitcher' not found in data")
+        return self.data[self.data['pitcher'] == pitcher_id]
+
+    def average_release_speed(self, pitcher_id: int = None) -> float:
+        """Calculate average release speed, optionally for a specific pitcher."""
+        self._ensure_loaded()
+        if 'release_speed' not in self.data.columns:
+            raise ValueError("Column 'release_speed' not found in data")
+        df = self.data
+        if pitcher_id is not None:
+            if 'pitcher' not in df.columns:
+                raise ValueError("Column 'pitcher' not found in data")
+            df = df[df['pitcher'] == pitcher_id]
+        return df['release_speed'].mean()
+
+    def summary_by_pitch_type(self) -> pd.DataFrame:
+        """Return average metrics grouped by pitch type."""
+        self._ensure_loaded()
+        if 'pitch_type' not in self.data.columns:
+            raise ValueError("Column 'pitch_type' not found in data")
+        summary_cols = [c for c in ['release_speed', 'release_spin_rate', 'swing', 'whiff'] if c in self.data.columns]
+        return self.data.groupby('pitch_type')[summary_cols].mean().reset_index()

--- a/tests/test_pitch_data.py
+++ b/tests/test_pitch_data.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from mlb_data_lab.pitch_data import PitchData
+
+
+def create_sample_csv(tmp_path):
+    csv_file = tmp_path / "sample.csv"
+    csv_file.write_text(
+        "pitcher,pitch_type,release_speed,release_spin_rate,swing,whiff\n"
+        "1,FF,95,2300,10,2\n"
+        "1,SL,86,2500,5,1\n"
+        "2,FF,96,2400,8,3\n"
+    )
+    return csv_file
+
+
+def test_load(tmp_path):
+    csv_file = create_sample_csv(tmp_path)
+    data = PitchData(file_name=str(csv_file), data_dir="").load()
+    assert len(data) == 3
+
+
+def test_pitches_by_pitcher(tmp_path):
+    csv_file = create_sample_csv(tmp_path)
+    pd_obj = PitchData(file_name=str(csv_file), data_dir="")
+    pd_obj.load()
+    pitches = pd_obj.pitches_by_pitcher(1)
+    assert len(pitches) == 2
+
+
+def test_average_release_speed(tmp_path):
+    csv_file = create_sample_csv(tmp_path)
+    pd_obj = PitchData(file_name=str(csv_file), data_dir="")
+    pd_obj.load()
+    overall = pd_obj.average_release_speed()
+    by_pitcher = pd_obj.average_release_speed(1)
+    assert overall == pd_obj.data['release_speed'].mean()
+    assert by_pitcher == 90.5
+
+
+def test_summary_by_pitch_type(tmp_path):
+    csv_file = create_sample_csv(tmp_path)
+    pd_obj = PitchData(file_name=str(csv_file), data_dir="")
+    summary = pd_obj.summary_by_pitch_type()
+    assert set(summary['pitch_type']) == {"FF", "SL"}


### PR DESCRIPTION
## Summary
- add pitch data CSV
- create `PitchData` class for loading and summarizing pitch information
- provide unit tests for the new functionality

## Testing
- `pytest tests/test_pitch_data.py tests/utils/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685332040d14832694881fd29dcfaa98