### PR TITLE
Fix imports in example scripts

### DIFF
--- a/examples/generate_player_summary.py
+++ b/examples/generate_player_summary.py
@@ -2,7 +2,12 @@
 
 import argparse
 import warnings
+from pathlib import Path
 from bs4 import MarkupResemblesLocatorWarning
+
+# Ensure the package can be imported when running from the examples directory
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from baseball_data_lab.player.player import Player
 from baseball_data_lab.summary_sheets.pitcher_summary_sheet import PitcherSummarySheet

--- a/examples/generate_team_summary.py
+++ b/examples/generate_team_summary.py
@@ -2,7 +2,12 @@
 
 import argparse
 import warnings
+from pathlib import Path
 from bs4 import MarkupResemblesLocatorWarning
+
+# Ensure the package can be imported when running from the examples directory
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from baseball_data_lab.team.team import Team
 from baseball_data_lab.summary_sheets.team_batting_sheet import TeamBattingSheet

--- a/examples/print_season_totals.py
+++ b/examples/print_season_totals.py
@@ -1,6 +1,11 @@
 import os
 import pandas as pd
 import re
+from pathlib import Path
+
+# Ensure the package can be imported when running from the examples directory
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from baseball_data_lab.config import LeagueTeams
 

--- a/examples/save_fangraphs_leaderboards.py
+++ b/examples/save_fangraphs_leaderboards.py
@@ -2,6 +2,11 @@
 
 import json
 import os
+from pathlib import Path
+
+# Ensure the package can be imported when running from the examples directory
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from baseball_data_lab.apis.unified_data_client import UnifiedDataClient
 from baseball_data_lab.config import DATA_DIR

--- a/examples/save_season_stats.py
+++ b/examples/save_season_stats.py
@@ -1,6 +1,12 @@
 
 import time
 import argparse
+from pathlib import Path
+
+# Ensure the package can be imported when running from the examples directory
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from baseball_data_lab.stats.save_season_stats import SeasonStatsDownloader
 
 

--- a/examples/save_statcast_data.py
+++ b/examples/save_statcast_data.py
@@ -1,6 +1,11 @@
 """CLI for saving Statcast data for players."""
 
 import argparse
+from pathlib import Path
+
+# Ensure the package can be imported when running from the examples directory
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from baseball_data_lab.player.player import Player
 from baseball_data_lab.team.roster import Roster


### PR DESCRIPTION
## Summary
- ensure example scripts can import `baseball_data_lab` by appending project root to `sys.path`
- update multiple scripts in `examples/` to avoid `ModuleNotFoundError`

## Testing
- `pytest`
- `python examples/generate_player_summary.py --players "John Doe" --year 2024`


------
https://chatgpt.com/codex/tasks/task_e_68a399beeb1883268bc4f956c5aaa95d