### PR TITLE
refactor: remove matplotlib dependency from constants

### DIFF
--- a/baseball_data_lab/constants.py
+++ b/baseball_data_lab/constants.py
@@ -1,7 +1,4 @@
-import matplotlib
-
-
-color_stats = ['velocity', 'release_extension', 'delta_run_exp_per_100', 
+color_stats = ['velocity', 'release_extension', 'delta_run_exp_per_100',
                'whiff_rate', 'in_zone_rate', 'chase_rate', 'xwoba']
 
 statcast_events = {
@@ -44,12 +41,6 @@ event_styles = {
 #     'HR': '#d62728',  # Red for home runs
 #     'LD': '#9467bd',  # Purple for line drives or another hit type
 # }
-
-
-# Define color maps
-cmap_sum = matplotlib.colors.LinearSegmentedColormap.from_list("", ['#648FFF','#FFFFFF','#FFB000'])
-cmap_sum_r = matplotlib.colors.LinearSegmentedColormap.from_list("", ['#FFB000','#FFFFFF','#648FFF'])
-
 
 # Define the codes for different types of swings and whiffs
 swing_code = ['foul_bunt','foul','hit_into_play','swinging_strike', 'foul_tip',

--- a/baseball_data_lab/data_viz/pitch_breakdown_table.py
+++ b/baseball_data_lab/data_viz/pitch_breakdown_table.py
@@ -12,10 +12,12 @@ from matplotlib import colors as mcolors
 from baseball_data_lab.config import StatsDisplayConfig
 from baseball_data_lab.config import pitch_summary_columns, pitch_colors
 from baseball_data_lab.constants import (
-    color_stats, 
-    cmap_sum, 
-    cmap_sum_r, 
+    color_stats,
 )
+
+# Define color maps locally to avoid importing matplotlib in constants
+cmap_sum = matplotlib.colors.LinearSegmentedColormap.from_list("", ['#648FFF', '#FFFFFF', '#FFB000'])
+cmap_sum_r = matplotlib.colors.LinearSegmentedColormap.from_list("", ['#FFB000', '#FFFFFF', '#648FFF'])
 
 
 class PitchBreakdownTable:


### PR DESCRIPTION
## Summary
- decouple constants module from matplotlib by relocating color maps to `pitch_breakdown_table`
- avoid unnecessary `ModuleNotFoundError` when importing core modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39bcbe1948326a0afa7931b61906c