### PR TITLE
Ensure exceptions package is importable

### DIFF
--- a/baseball_data_lab/exceptions/__init__.py
+++ b/baseball_data_lab/exceptions/__init__.py
@@ -1,0 +1,16 @@
+"""Custom exceptions for baseball_data_lab package."""
+from .custom_exceptions import (
+    NoFangraphsIdError,
+    PlayerNotFoundError,
+    PositionMismatchError,
+    NoStatsError,
+    StatFetchError,
+)
+
+__all__ = [
+    "NoFangraphsIdError",
+    "PlayerNotFoundError",
+    "PositionMismatchError",
+    "NoStatsError",
+    "StatFetchError",
+]


### PR DESCRIPTION
## Summary
- add missing `__init__.py` to include custom exceptions package

## Testing
- `pytest tests/apis/test_fangraphs_client.py -q`
- `pytest tests/apis/test_mlb_stats_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39d93abc08326bac03c7d60647f13