### PR TITLE
Ensure exceptions package is importable

### DIFF
--- a/baseball_data_lab/__init__.py
+++ b/baseball_data_lab/__init__.py
@@ -16,5 +16,22 @@ except PackageNotFoundError:  # pragma: no cover - fallback for local usage
 from .player.player import Player
 from .summary_sheets.pitcher_summary_sheet import PitcherSummarySheet
 from .summary_sheets.batter_summary_sheet import BatterSummarySheet
+from .exceptions import (
+    NoFangraphsIdError,
+    PlayerNotFoundError,
+    PositionMismatchError,
+    NoStatsError,
+    StatFetchError,
+)
 
-__all__ = ["Player", "PitcherSummarySheet", "BatterSummarySheet", "__version__"]
+__all__ = [
+    "Player",
+    "PitcherSummarySheet",
+    "BatterSummarySheet",
+    "NoFangraphsIdError",
+    "PlayerNotFoundError",
+    "PositionMismatchError",
+    "NoStatsError",
+    "StatFetchError",
+    "__version__",
+]

--- a/baseball_data_lab/exceptions/__init__.py
+++ b/baseball_data_lab/exceptions/__init__.py
@@ -1,0 +1,16 @@
+"""Custom exceptions for baseball_data_lab package."""
+from .custom_exceptions import (
+    NoFangraphsIdError,
+    PlayerNotFoundError,
+    PositionMismatchError,
+    NoStatsError,
+    StatFetchError,
+)
+
+__all__ = [
+    "NoFangraphsIdError",
+    "PlayerNotFoundError",
+    "PositionMismatchError",
+    "NoStatsError",
+    "StatFetchError",
+]


### PR DESCRIPTION
## Summary
- expose custom exceptions at package root for easier importing

## Testing
- `pytest tests/apis/test_fangraphs_client.py -q`
- `pytest tests/apis/test_mlb_stats_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a39d93abc08326bac03c7d60647f13