### PR TITLE
refactor: move DataConverter to dedicated module

### DIFF
--- a/baseball_data_lab/data_converter.py
+++ b/baseball_data_lab/data_converter.py
@@ -1,0 +1,51 @@
+import os
+import pandas as pd
+
+from baseball_data_lab.config import DATA_DIR
+
+
+class DataConverter:
+    """Utility class for converting CSV data to JSON and generating team data."""
+
+    def __init__(self, input_dir: str = DATA_DIR, output_dir: str = DATA_DIR):
+        self.input_dir = input_dir
+        self.output_dir = output_dir
+
+    def csv_to_json(self, csv_filename: str, json_filename: str):
+        """Convert a CSV file to a JSON Lines file."""
+        csv_path = os.path.join(self.input_dir, csv_filename)
+        json_path = os.path.join(self.output_dir, json_filename)
+
+        try:
+            df = pd.read_csv(csv_path)
+        except FileNotFoundError:
+            print(f"CSV file not found: {csv_path}")
+            return
+        except pd.errors.EmptyDataError:
+            print(f"CSV file is empty: {csv_path}")
+            return
+
+        df.to_json(json_path, orient="records", lines=True)
+        print(f"File converted and saved as JSON: {json_path}")
+
+    def create_current_teams_json(self):
+        """Create a JSON Lines file of current teams from a Fangraphs CSV file."""
+        teams_csv = os.path.join(self.input_dir, "fangraphs_teams.csv")
+        teams_json = os.path.join(self.output_dir, "current_teams.json")
+
+        teams_df = pd.read_csv(teams_csv)
+        teams_df = teams_df[teams_df["yearID"] == 2021]
+        teams_df = teams_df[
+            [
+                "ID",
+                "yearID",
+                "lgID",
+                "teamID",
+                "franchID",
+                "teamIDfg",
+                "teamIDBR",
+                "teamIDretro",
+            ]
+        ]
+        teams_df.to_json(teams_json, orient="records", lines=True)
+        print(f"Current teams JSON created: {teams_json}")

--- a/baseball_data_lab/utils.py
+++ b/baseball_data_lab/utils.py
@@ -2,7 +2,6 @@ import json
 import numpy as np
 import pandas as pd
 import os
-from baseball_data_lab.config import DATA_DIR
 from baseball_data_lab.config import BASE_DIR
 from baseball_data_lab.apis.chadwick_register import PlayerSearchClient
 from baseball_data_lab.exceptions.custom_exceptions import NoFangraphsIdError
@@ -106,49 +105,6 @@ class Utils:
         
         # If format_spec is not a string, raise an error or handle appropriately
         raise TypeError(f"Invalid format_spec: {format_spec}. Expected a string or callable.")
-
-
-class DataConverter:
-    def __init__(self, input_dir: str=DATA_DIR, output_dir: str=DATA_DIR):
-        self.input_dir = input_dir
-        self.output_dir = output_dir
-
-    def csv_to_json(self, csv_filename: str, json_filename: str):
-        # Build file paths
-        csv_path = os.path.join(self.input_dir, csv_filename)
-        json_path = os.path.join(self.output_dir, json_filename)
-
-        # Read the CSV file
-        try:
-            df = pd.read_csv(csv_path)
-        except FileNotFoundError:
-            print(f"CSV file not found: {csv_path}")
-            return
-        except pd.errors.EmptyDataError:
-            print(f"CSV file is empty: {csv_path}")
-            return
-
-        # Convert to JSON and save
-        df.to_json(json_path, orient="records", lines=True)
-        print(f"File converted and saved as JSON: {json_path}")
-
-
-    def create_current_teams_json(self):
-        teams_csv = os.path.join(self.input_dir, 'fangraphs_teams.csv')
-        teams_json = os.path.join(self.output_dir, 'current_teams.json')
-
-        # Read the CSV file
-        teams_df = pd.read_csv(teams_csv)
-
-        # Filter for teams with yearID of 2021
-        teams_df = teams_df[teams_df['yearID'] == 2021]
-
-        # Select specific columns
-        teams_df = teams_df[['ID', 'yearID', 'lgID', 'teamID', 'franchID', 'teamIDfg', 'teamIDBR', 'teamIDretro']]
-        
-        # Save the filtered data to JSON
-        teams_df.to_json(teams_json, orient="records", lines=True)
-        print(f"Current teams JSON created: {teams_json}")
 
 
 

--- a/tests/utils/test_data_converter.py
+++ b/tests/utils/test_data_converter.py
@@ -1,0 +1,65 @@
+import json
+import pandas as pd
+
+from baseball_data_lab.data_converter import DataConverter
+
+
+def test_csv_to_json_success(tmp_path):
+    df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
+    csv_file = tmp_path / 'input.csv'
+    df.to_csv(csv_file, index=False)
+    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
+    converter.csv_to_json('input.csv', 'output.json')
+    output_file = tmp_path / 'output.json'
+    assert output_file.exists()
+    with open(output_file) as f:
+        lines = [json.loads(line) for line in f]
+    assert lines == [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
+
+
+def test_csv_to_json_missing_file(tmp_path, capsys):
+    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
+    converter.csv_to_json('missing.csv', 'out.json')
+    captured = capsys.readouterr().out
+    assert 'CSV file not found' in captured
+    assert not (tmp_path / 'out.json').exists()
+
+
+def test_csv_to_json_empty_file(tmp_path, capsys):
+    empty = tmp_path / 'empty.csv'
+    empty.write_text('')
+    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
+    converter.csv_to_json('empty.csv', 'out.json')
+    captured = capsys.readouterr().out
+    assert 'CSV file is empty' in captured
+
+
+def test_create_current_teams_json(tmp_path):
+    df = pd.DataFrame({
+        'ID': [1, 2],
+        'yearID': [2021, 2020],
+        'lgID': ['AL', 'NL'],
+        'teamID': ['T1', 'T2'],
+        'franchID': ['F1', 'F2'],
+        'teamIDfg': [111, 222],
+        'teamIDBR': ['B1', 'B2'],
+        'teamIDretro': ['R1', 'R2']
+    })
+    teams_csv = tmp_path / 'fangraphs_teams.csv'
+    df.to_csv(teams_csv, index=False)
+    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
+    converter.create_current_teams_json()
+    output_file = tmp_path / 'current_teams.json'
+    assert output_file.exists()
+    with open(output_file) as f:
+        lines = [json.loads(line) for line in f]
+    assert lines == [{
+        'ID': 1,
+        'yearID': 2021,
+        'lgID': 'AL',
+        'teamID': 'T1',
+        'franchID': 'F1',
+        'teamIDfg': 111,
+        'teamIDBR': 'B1',
+        'teamIDretro': 'R1'
+    }]

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,9 +1,7 @@
-import os
 import json
-import pandas as pd
 import numpy as np
 import pytest
-from baseball_data_lab.utils import Utils, DataConverter
+from baseball_data_lab.utils import Utils
 
 
 def test_format_stat_variants():
@@ -26,64 +24,3 @@ def test_ensure_directory_exists(tmp_path):
     file_path = tmp_path / 'a' / 'b' / 'file.txt'
     Utils.ensure_directory_exists(file_path)
     assert (tmp_path / 'a' / 'b').is_dir()
-
-
-def test_csv_to_json_success(tmp_path):
-    df = pd.DataFrame({'A': [1, 2], 'B': [3, 4]})
-    csv_file = tmp_path / 'input.csv'
-    df.to_csv(csv_file, index=False)
-    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
-    converter.csv_to_json('input.csv', 'output.json')
-    output_file = tmp_path / 'output.json'
-    assert output_file.exists()
-    with open(output_file) as f:
-        lines = [json.loads(line) for line in f]
-    assert lines == [{'A': 1, 'B': 3}, {'A': 2, 'B': 4}]
-
-
-def test_csv_to_json_missing_file(tmp_path, capsys):
-    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
-    converter.csv_to_json('missing.csv', 'out.json')
-    captured = capsys.readouterr().out
-    assert 'CSV file not found' in captured
-    assert not (tmp_path / 'out.json').exists()
-
-
-def test_csv_to_json_empty_file(tmp_path, capsys):
-    empty = tmp_path / 'empty.csv'
-    empty.write_text('')
-    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
-    converter.csv_to_json('empty.csv', 'out.json')
-    captured = capsys.readouterr().out
-    assert 'CSV file is empty' in captured
-
-
-def test_create_current_teams_json(tmp_path):
-    df = pd.DataFrame({
-        'ID': [1, 2],
-        'yearID': [2021, 2020],
-        'lgID': ['AL', 'NL'],
-        'teamID': ['T1', 'T2'],
-        'franchID': ['F1', 'F2'],
-        'teamIDfg': [111, 222],
-        'teamIDBR': ['B1', 'B2'],
-        'teamIDretro': ['R1', 'R2']
-    })
-    teams_csv = tmp_path / 'fangraphs_teams.csv'
-    df.to_csv(teams_csv, index=False)
-    converter = DataConverter(input_dir=str(tmp_path), output_dir=str(tmp_path))
-    converter.create_current_teams_json()
-    output_file = tmp_path / 'current_teams.json'
-    assert output_file.exists()
-    with open(output_file) as f:
-        lines = [json.loads(line) for line in f]
-    assert lines == [{
-        'ID': 1,
-        'yearID': 2021,
-        'lgID': 'AL',
-        'teamID': 'T1',
-        'franchID': 'F1',
-        'teamIDfg': 111,
-        'teamIDBR': 'B1',
-        'teamIDretro': 'R1'
-    }]


### PR DESCRIPTION
## Summary
- move DataConverter from utils into new `data_converter` module
- trim utils module to lightweight helpers
- adjust and expand tests for new module location

## Testing
- `pytest tests/utils -q`


------
https://chatgpt.com/codex/tasks/task_e_68b89e778cbc8326b5fa29067832bf06