### PR TITLE
refactor: unify team logo retrieval

### DIFF
--- a/baseball_data_lab/summary_sheets/base_sheet.py
+++ b/baseball_data_lab/summary_sheets/base_sheet.py
@@ -56,7 +56,7 @@ class BaseSheet:
                 Plotting.plot_bio(self.ax_bio, self.player, "Season Batting Summary", self.season)
             Plotting.plot_image(
                 self.ax_logo,
-                self.player.current_team.get_team_logo(self.player.current_team.abbrev),
+                self.player.current_team.get_logo(),
             )
         elif hasattr(self, "team"):
             Plotting.plot_team_info(

--- a/baseball_data_lab/team/team.py
+++ b/baseball_data_lab/team/team.py
@@ -37,10 +37,11 @@ class Team:
         self.season_stats = None # Team stats for a given season
         
 
-    def get_logo(self):
-        if self.abbrev not in team_logo_urls:
+    def get_logo(self, abbrev: str | None = None):
+        abbrev = self.abbrev if abbrev is None else abbrev
+        if abbrev not in team_logo_urls:
             return None
-        return self.data_client.fetch_logo_img(team_logo_urls[self.abbrev])
+        return self.data_client.fetch_logo_img(team_logo_urls[abbrev])
     
     def set_season_roster(self, season):
         self.season_roster = Roster()
@@ -71,12 +72,6 @@ class Team:
         team = team[-1]
         self.fangraphs_id = team['teamIDfg']
     
-
-    def get_team_logo(self, abbrev: str):
-        if abbrev not in team_logo_urls:
-            return None
-        return self.data_client.fetch_logo_img(team_logo_urls[abbrev])
-
     @staticmethod
     def create_from_mlb(team_id: int = None, team_name: str = None, season: int = 2024, data_client: Optional[UnifiedDataClient] = None):
         if team_id is None and team_name is None:


### PR DESCRIPTION
## Summary
- consolidate team logo retrieval into `Team.get_logo`
- update summary sheet to use unified method

## Testing
- `pytest`
- `pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68b9268ee5dc832696467857456e696b