### PR TITLE
Handle raw split stats in StatsDisplay

### DIFF
--- a/baseball_data_lab/stats/stats_display.py
+++ b/baseball_data_lab/stats/stats_display.py
@@ -5,6 +5,7 @@ import matplotlib.pyplot as plt
 from baseball_data_lab.config.stats import StatsConfig
 from baseball_data_lab.data_viz.stats_table import StatsTable
 from baseball_data_lab.player.player import Player
+from baseball_data_lab.apis.mlb_stats_client import process_splits
 
 
 class StatsDisplay:
@@ -28,8 +29,17 @@ class StatsDisplay:
         if self.player.player_splits_stats is None:
             print("No splits stats data available.")
             return
-        
-        self._plot_stats_table(self.player.player_splits_stats, self.season_stats['splits'], ax, 'Splits', is_splits=True)
+
+        splits_data = self.player.player_splits_stats
+        # The Stats API returns a list of split dictionaries.  ``StatsTable``
+        # expects a ``DataFrame`` when generating a table, so convert the list
+        # to a properly-indexed ``DataFrame`` when necessary.
+        if isinstance(splits_data, list):
+            splits_data = process_splits(splits_data)
+
+        self._plot_stats_table(
+            splits_data, self.season_stats["splits"], ax, "Splits", is_splits=True
+        )
 
 
     # def _plot_stat_data(self, data, stat_type: str, ax: plt.Axes, title: str):

--- a/tests/stats/test_stats_display.py
+++ b/tests/stats/test_stats_display.py
@@ -127,13 +127,11 @@ def test_plot_splits_stats(stats_display, capture_plot, sample_batter_stat_split
         {k: v for k, v in split.get("stat", {}).items() if k in expected_fields}
         for split in sample_batter_stat_splits
     ]
-    expected_df = pd.DataFrame(expected_stats).reset_index(drop=True)
+    expected_df = pd.DataFrame(expected_stats)[expected_fields]
 
-    actual_stats = [
-        {k: v for k, v in split.get("stat", {}).items() if k in expected_fields}
-        for split in call["stats"]
-        if "stat" in split
-    ]
-    actual_df = pd.DataFrame(actual_stats).reset_index(drop=True)
-    pd.testing.assert_frame_equal(actual_df, expected_df, check_like=True)
+    assert isinstance(call["stats"], pd.DataFrame)
+    actual_df = call["stats"][expected_fields].reset_index(drop=True)
+    pd.testing.assert_frame_equal(
+        actual_df, expected_df.reset_index(drop=True), check_like=True
+    )
 


### PR DESCRIPTION
## Summary
- Convert raw split stats lists into DataFrames before plotting
- Update StatsDisplay tests for DataFrame-based splits

## Testing
- `pytest tests/stats/test_stats_display.py::test_plot_splits_stats -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0d2a4c6948326929868a04132178c